### PR TITLE
-Fixed issue with Spanish -> English transition

### DIFF
--- a/frontend/index_es.html
+++ b/frontend/index_es.html
@@ -193,7 +193,7 @@
             <script >
               function getEnglishPage(){
                 const STUDY_NAME_HREF = _getStudyName(window.location);
-                window.location.href = `/?study_config=${STUDY_NAME_HREF}`;
+                window.location.href = `index.html?study_config=${STUDY_NAME_HREF}`;
               }
             </script>
           </div>
@@ -341,7 +341,7 @@
                   
                </ul>
                
-               <p>Una vez finalizado el estudio, los datos se archivarán en el <a href="https://www.nrel.gov/transportation/secure-transportation-data/index.html">Centro de Datos de Transporte de NREL</a> para apoyar la investigación sobre el comportamiento de los viajeros.
+               <p>Una vez finalizado el estudio, los datos se archivarán en el <a href="https://www.nrel.gov/transportation/secure-transportation-data/index.html">Transporte Centro de Datos Seguro de NREL</a> para apoyar la investigación sobre el comportamiento de los viajeros.
                </p>
                
                <p>Entre los ejemplos de investigaciones que podrían utilizar los datos se incluyen: </p>


### PR DESCRIPTION
English->Spanish and Spanish->English transition button. (Code updated) ✔️ **Working**
All links.  ✔️**Working**
joinStudyLink (at line 306). ❌**Not Working**

Conclusion:
- Everything is working except the join study link (nrelopenpath://join_study?label=uprm-civic&source=github). This is something that we never touched nor modified. We believe that the problem is not the code, but its possible that the URL is written incorrectly.
- This is the link: <img width="369" alt="Capture" src="https://user-images.githubusercontent.com/70666860/209772585-849dfb68-6004-40ac-a063-1f316691e529.PNG">
