### PR TITLE
🌐 Translate the error messages on the join page as well

### DIFF
--- a/frontend/i18n/en.json
+++ b/frontend/i18n/en.json
@@ -74,5 +74,7 @@
     "pageLoadError": "Error loading page elements",
     "tokenCreationError": "Error creating opcode token",
     "contactForAssistance": "Please contact $1 for assistance",
-    "invalidSubgroupError": "Subgroup $1 not found in list $2"
+    "invalidSubgroupError": "Subgroup $1 not found in list $2",
+    "errorCopyingToClipboard": "Error copying to clipboard",
+    "errorLoadingPageElements": "Error loading page elements"
 }

--- a/frontend/i18n/es.json
+++ b/frontend/i18n/es.json
@@ -74,5 +74,7 @@
     "pageLoadError": "Error al cargar elementos de la página",
     "tokenCreationError": "Error al crear token de 'opcode'",
     "contactForAssistance": "Póngase en contacto con $1 para obtener ayuda",
-    "invalidSubgroupError": "Subgrupo $1 no encontrado en la lista $2"
+    "invalidSubgroupError": "Subgrupo $1 no encontrado en la lista $2",
+    "errorCopyingToClipboard": "Error al copiar al portapapeles",
+    "errorLoadingPageElements": "Error al cargar elementos de la página"
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -675,7 +675,7 @@
                     // alert("Copied opcode "+GEN_TOKEN+" to clipboard");
                   },
                   () => {
-                    alert("Error copying opcode "+GEN_TOKEN+" to clipboard");
+                    alert($.i18n("errorCopyingToClipboard")+": '"+GEN_TOKEN+"'");
                   }
                 );
             } );
@@ -760,8 +760,8 @@
                 hideTokenAndURL();
             }
             redisplayPage();
-        }).catch((error) => setInvalid("Error loading page elements",
-            error, "Please contact k.shankari@nrel.gov for assistance"));
+        }).catch((error) => setInvalid($.i18n("errorLoadingPageElements"),
+            error, $.i18n("contactForAssistance", "k.shankari@nrel.gov")));
         // the error elements are hardcoded here because we may have an error
         // in loading the i18n, in which case we will not have i18n-ized text
         // available to display.


### PR DESCRIPTION
They are not actually used, since:
- I have never seen the clipboard action fail
- We always load the page first in English

But at least when we fix https://github.com/e-mission/e-mission-docs/issues/905 we are ready for things to work

This is the final final fix for
https://github.com/e-mission/e-mission-docs/issues/850