### PR TITLE
Fix lang load timing

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -850,7 +850,6 @@
         // https://stackoverflow.com/questions/1414365/disable-enable-an-input-with-jquery
         Promise.all(otherI18nLoadPromises).then(() => {
             console.log("Finished loading other languages "+toLoadLanguages);
-            // setTimeout(() => {  console.log("waited!"); }, 5000);
             //now that all i18n have been loaded, get map
             LANG_TO_NAME = makeKeyNameMap(SUPPORTED_LANGUAGES);
             // populate the menu! (could be delayed if lots of languages?)

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -833,6 +833,7 @@
         console.log("Default i18n result is", i18nLoadResult);
 
         //show the page now that we have sufficent information!
+        $.i18n().locale = default_language;
         redisplayPage();
         
         //determined that traditional promise was working better than the await...


### PR DESCRIPTION
Addressing issue where some messages in the default language were not loading, and the keys were showing. I determined this was because the i18n locale was not set in the appropriate place. It was set during the creation of the languauge menu, and when the language was changed, but not on initial loading of the i18n for the default language and reloading the page with that information. This PR fixes that language. 

I checked a few different configs and loaded the pages a few times to verify that this was the only solution required. 