### PR TITLE
Update OPCODE_AUTOGEN conditions

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -812,7 +812,12 @@
         console.log("Dynamic Config result is", data);
 
         //create token and token url
-        OPCODE_AUTOGEN = data.opcode?.autogen || data.intro.program_or_study == "study";
+        if(data.opcode?.autogen) { //if the autogen property is set, use it
+          OPCODE_AUTOGEN = data.opcode?.autogen;
+        } else { //else fall back to program vs study
+          OPCODE_AUTOGEN = data.intro.program_or_study == "study";
+        }
+        
         if (OPCODE_AUTOGEN) {
           validateAndGenerateToken();
         } else {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -812,12 +812,14 @@
         console.log("Dynamic Config result is", data);
 
         //create token and token url
-        if(data.opcode?.autogen) { //if the autogen property is set, use it
+        if(typeof data.opcode?.autogen !== 'undefined') { //if the autogen property is set, use it
+          console.log("found opcode setting, is", data.opcode.autogen);
           OPCODE_AUTOGEN = data.opcode?.autogen;
         } else { //else fall back to program vs study
+          console.log("falling back to program vs study", data.intro.program_or_study);
           OPCODE_AUTOGEN = data.intro.program_or_study == "study";
         }
-        
+
         if (OPCODE_AUTOGEN) {
           validateAndGenerateToken();
         } else {


### PR DESCRIPTION
Sometimes, a study might want to not have autogenerated opcodes, but that is not currently something that we accommodate. Therefore, we need to update the conditions. 

I have changed the code so that if the autogen property is set in the config, that is what is used. If that property is not set, then all studies will be autogenerated and all programs will not be. 