### PR TITLE
Docker base node image upgraded.

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:19-alpine
+FROM node:20.7.0-alpine
 
 RUN mkdir -p /public
 WORKDIR /public
@@ -6,7 +6,6 @@ WORKDIR /public
 RUN npm i -g http-server
 
 RUN apk update && apk upgrade busybox
-RUN npm update -g
 
 COPY client /public/client
 COPY *.html /public/

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:19-alpine
+FROM node:20.7.0-alpine
 
 RUN mkdir -p /public
 WORKDIR /public
@@ -6,7 +6,6 @@ WORKDIR /public
 RUN npm i -g http-server
 
 RUN apk update && apk upgrade busybox
-RUN npm update -g
 
 EXPOSE 5050
 CMD ["http-server", "-p", "5050"]


### PR DESCRIPTION
Semver version upgrade required updating npm to latest version containing update semver package.

- Previous commit includes unversioned npm package upgraded.
- But node base image upgrade is recommended over generalized unversioned upgrade so as to have more control over installed package versions.

Found latest tested and analyzed base image [here](https://hub.docker.com/_/node/tags?name=alpine) - using node:20.7.0-alpine as the base image.
- While newer versions exist, they were uploaded recently (about a day ago) and didn’t have vulnerability analysis available yet.
- Hence going ahead with next latest available version (uploaded about 3 weeks ago).