### PR TITLE
Fixing latest Docker image vulnerabilities

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:21.5.0-alpine
 
 RUN mkdir -p /public
 WORKDIR /public

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,11 +1,9 @@
-FROM node:20.7.0-alpine
+FROM node:20-alpine
 
 RUN mkdir -p /public
 WORKDIR /public
 
 RUN npm i -g http-server
-
-RUN apk update && apk upgrade busybox
 
 COPY client /public/client
 COPY *.html /public/

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:21.5.0-alpine
 
 RUN mkdir -p /public
 WORKDIR /public

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,11 +1,9 @@
-FROM node:20.7.0-alpine
+FROM node:20-alpine
 
 RUN mkdir -p /public
 WORKDIR /public
 
 RUN npm i -g http-server
-
-RUN apk update && apk upgrade busybox
 
 EXPOSE 5050
 CMD ["http-server", "-p", "5050"]


### PR DESCRIPTION
Upgrading Node base image
1. Includes latest version upgrades for detected vulnerable packages - openssl.

2. Removed busy box upgrade as latest secure version is available in the base image upgrade itself. Had added it in the previous PR as back then base image didn’t have the latest package version.