### PR TITLE
Redesign Build Deployment Process (External)

### DIFF
--- a/.github/workflows/image_build_push.yml
+++ b/.github/workflows/image_build_push.yml
@@ -1,33 +1,21 @@
-# This is a basic workflow to help you get started with Actions
-
 name: docker-image-push-join
 
-# Controls when the action will run. Triggers the workflow on push or pull request 
-# events but only for the master branch
 on:
   push:
-    # Mukul:
-    # I've added a local test branch on my system and using it for testing image push.
-    # So, for testing purposes, need to checkout a branch "image-push-merge"
-    # TODO: Need to change to build off master or main once it looks good.
-    branches: [ image-push-merge ]
+    branches: [ main ]
 
-
-# Env variable
 env:
   DOCKER_USER: ${{secrets.DOCKER_USER}}
   DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
+
   build:
-    # The type of runner that the job will run on
+
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+
     - uses: actions/checkout@v2
     - name: docker login
       run: | # log into docker hub account
@@ -37,11 +25,9 @@ jobs:
       id: date
       run: echo "::set-output name=date::$(date +'%Y-%m-%d--%M-%S')"
 
-    #Runs a single command using the runners shell
     - name: Run a one-line script
       run: echo running in repo ${GITHUB_REPOSITORY#*/} branch ${GITHUB_REF##*/} on ${{ steps.date.outputs.date }}
 
-    # Runs a set of commands using the runners shell
     - name: build docker image
       run: |
         docker build -t $DOCKER_USER/${GITHUB_REPOSITORY#*/}:${GITHUB_REF##*/}_${{ steps.date.outputs.date }} ./frontend


### PR DESCRIPTION
This PR serves as the implementation for [this issue](https://github.com/e-mission/e-mission-docs/issues/1048) for redesigning our build and deployment processes across e-mission-server, join, admin-dash, public-dash primarily.

Collaborating on this along with @nataliejschultz .

All four redesign PRs for the external repos:
E-mission-server: https://github.com/e-mission/e-mission-server/pull/961
Join: https://github.com/e-mission/nrel-openpath-join-page/pull/29
Admin-dash: https://github.com/e-mission/op-admin-dashboard/pull/113
Public-dash: https://github.com/e-mission/em-public-dashboard/pull/125

-------------

A rough plan can be:

1st phase
- Consolidating Differences
  - Minimize the differences in internal and external versions, cleanup unnecessary files, so on.
- Image_Build_Push.yml: 
  - CI / CD via GitHub actions to build and push images to Dockerhub for all four repos based on the current process for e-mission-server.
  - Image build push only builds for that specific repo when merge is made to a specific branch.
  - Additionally, for e-mission-server, image-build-push will now also need to trigger the GitHub action in join, admin-dash, public-dash.

2nd phase: 
- Multi-tier uniform repo structure in nrelopenpath
  - Need to change the internal repos to pull from the externally built images for each repo without duplicating the entire external code repository internally.