### PR TITLE
Latest vulnerability fixes - ip

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:21.5.0-alpine
+FROM node:21.7.2-alpine
 
 RUN mkdir -p /public
 WORKDIR /public

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:21.5.0-alpine
+FROM node:21.7.2-alpine
 
 RUN mkdir -p /public
 WORKDIR /public


### PR DESCRIPTION
Summary
1 CRITICAL package - ip

1. Upgrading node-alpine docker image to latest available version.
This node image does not contain the ip package at all. Additionally, the latest ip version 2.0.1 might not contain the remediation as yet.

---------------

DETAILS

---------------

Packages present in:
$ cd /usr/local/lib/node_modules/npm/node_modules

Checked packages list and version number using:
$ apk info
$ apk list -i | grep ip

1. ip

Initially, a [new node-alpine version](https://hub.docker.com/layers/library/node/21.7.1-alpine/images/sha256-58c5c8d40911b57fef25117fd9bb162e6eb2d5c152006d3969fc46ca1b058665?context=explore
) was released but it had only 23 packages while originally the previous node images had 240 packages.


The official github [repo for ip package](https://github.com/indutny/node-ip/pull/143) shows updated version.
However, the latest update version 2.0.1 might not be safe as mentioned in this [stackoverflow post]([https://stackoverflow.com/a/78011877](https://stackoverflow.com/questions/78011665/npm-ip-package-vulnerable-to-server-side-request-forgery-ssrf-attacks)).


Now, another [newer version](https://hub.docker.com/layers/library/node/21.7.2-alpine/images/sha256-ed4880bea0d76e280073698d18ebd056e792cabc40ab3184c006edb22db8ffe7?context=explore) is available which has 233 packages but no ip package.  
This package has an ip-address package though which was not there in the previous node image version. 


But still going ahead with this.


Upgraded to node:21.7.2-alpine



